### PR TITLE
Create How to transfer file from Windows to zOS with command line ftp

### DIFF
--- a/zOS System operating/System operating scenarios/How to transfer file from Windows to zOS
+++ b/zOS System operating/System operating scenarios/How to transfer file from Windows to zOS
@@ -1,0 +1,26 @@
+FTP to ZITSO13
+
+C:\Users\shaklein_ia>ftp stutvs13.megacenter.by.iba.com
+Connected to STUTVS13.megacenter.by.iba.com.
+220-TCPFTPH1 IBM FTP CS V2R4 at STUTVS13.megacenter.by.iba.com, 09:03:04 on 2021-04-12.
+220 Connection will close if idle for more than 5 minutes.
+501 command OPTS aborted -- no options supported for UTF8
+User (STUTVS13.megacenter.by.iba.com:(none)): e544271
+331 Send password please.
+Password: _______
+230 E544271 is logged on.  Working directory is "E544271.".
+ftp> ascii
+200 Representation type is Ascii NonPrint
+ftp> quote site lrecl=146 recfm=fb prim=20 sec=20 cyl
+200-BLOCKSIZE must be a multiple of LRECL for RECFM FB
+200-BLOCKSIZE being set to 6132
+200 SITE command was accepted
+ftp> put d:\downloads\USC.WRK.NOINTER.APFDBU.ACCESS2 'usc.wrktish.nointer.apfdbu.access2'
+200 Port request OK.
+125 Storing data set USC.WRKTISH.NOINTER.APFDBU.ACCESS2
+250 Transfer completed successfully.
+ftp: 16364508 bytes sent in 8.56Seconds 1911.52Kbytes/sec.
+ftp> quit
+221 Quit command received. Goodbye.
+
+C:\Users\shaklein_ia>


### PR DESCRIPTION
To transfer files from Windows to z/OS (especially when z/OS file must be created with specific LRECL , RECFM, size, etc) - good way is to use **ftp** line command, entered in command prompt (Run->cmd ) window. Below highlighted are few commands used to transfer character(not binary !) Windows file d:\downloads\USC.WRK.NOINTER.APFDBU.ACCESS2  to z/OS dataset USC.WRKTISH.NOINTER.APFDBU.ACCESS2

C:\Users\shaklein_ia>**ftp stutvs13.megacenter.by.iba.com**
Connected to STUTVS13.megacenter.by.iba.com.
220-TCPFTPH1 IBM FTP CS V2R4 at STUTVS13.megacenter.by.iba.com, 09:03:04 on 2021-04-12.
220 Connection will close if idle for more than 5 minutes.
501 command OPTS aborted -- no options supported for UTF8
User (STUTVS13.megacenter.by.iba.com:(none)): **e544271**
331 Send password please.
Password: ****_______****
230 E544271 is logged on.  Working directory is "E544271.".
ftp> **ascii**
200 Representation type is Ascii NonPrint
ftp> **quote site lrecl=146 recfm=fb prim=20 sec=20 cyl**
200-BLOCKSIZE must be a multiple of LRECL for RECFM FB
200-BLOCKSIZE being set to 6132
200 SITE command was accepted
ftp> **put d:\downloads\USC.WRK.NOINTER.APFDBU.ACCESS2 'usc.wrktish.nointer.apfdbu.access2'**
200 Port request OK.
125 Storing data set USC.WRKTISH.NOINTER.APFDBU.ACCESS2
250 Transfer completed successfully.
ftp: 16364508 bytes sent in 8.56Seconds 1911.52Kbytes/sec.
ftp> **quit**
221 Quit command received. Goodbye.

C:\Users\shaklein_ia>
